### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The Time machine theme is intended to make it quick and easy for GitHub Pages us
 
 ## Contributing
 
-Interested in contributing to Time machine? We'd love your help. Time machine is an open source project, built one contribution at a time by users like you. See [the CONTRIBUTING file](CONTRIBUTING.md) for instructions on how to contribute.
+Interested in contributing to Time machine? We'd love your help. Time machine is an open source project, built one contribution at a time by users like you. See [the CONTRIBUTING file](docs/CONTRIBUTING.md) for instructions on how to contribute.
 
 ### Previewing the theme locally
 


### PR DESCRIPTION
The contributing link in the readme leads to a 404. This pull request makes it lead to the correct CONTRIBUTING file.