### PR TITLE
Allow non-superusers to use the script.

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,5 +2,5 @@
 
 set -e
 
-gem install bundler
+bundle config set --local path 'vendor/bundle'
 bundle install


### PR DESCRIPTION
On my computer I am not a administrator/super user so can't run `gem install bundler`
However, I edited the file to have `bundle config set --local path 'vendor/bundle'` and that worked fine for me.
And this is better as it is only available for the users who actually need it.

Hope this is a good proposal!

I am using MacOS Catalina 10.15.7 so I don't know and can't test if it works on other operating systems. But I think that it should.