### PR TITLE
Add _sass/time-machine.scss to allow importing with theme name while using jekyll-remote-theme

### DIFF
--- a/_sass/time-machine.scss
+++ b/_sass/time-machine.scss
@@ -1,0 +1,4 @@
+// Placeholder file. If your site uses
+//     @import "{{ site.theme }}";
+// Then using this theme with jekyll-remote-theme will work fine.
+@import "jekyll-theme-time-machine";


### PR DESCRIPTION
Allows use of `@import {{site.theme}}` when you have `remote_theme: pages-theme/time-machine@v0.2.0` in your `_config.yml`.